### PR TITLE
Mapping .jstests to the JavaScript editor

### DIFF
--- a/DanTup.TestAdapters.Jasmine.Vsix/DanTup.TestAdapters.Jasmine.Vsix.csproj
+++ b/DanTup.TestAdapters.Jasmine.Vsix/DanTup.TestAdapters.Jasmine.Vsix.csproj
@@ -4,6 +4,10 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+    <ZipPackageCompressionLevel>Normal</ZipPackageCompressionLevel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/DanTup.TestAdapters.Jasmine/DanTup.TestAdapters.Jasmine.csproj
+++ b/DanTup.TestAdapters.Jasmine/DanTup.TestAdapters.Jasmine.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -51,6 +52,7 @@
     <Compile Include="..\DanTup.TestAdapters\Properties\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="JasminTestContentTypeDefinition.cs" />
     <Compile Include="JasmineTestContainerDiscoverer.cs" />
     <Compile Include="JasmineTestDiscoverer.cs" />
     <Compile Include="JasmineExternalTestExecutor.cs" />

--- a/DanTup.TestAdapters.Jasmine/JasminTestContentTypeDefinition.cs
+++ b/DanTup.TestAdapters.Jasmine/JasminTestContentTypeDefinition.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Utilities;
+
+namespace DanTup.TestAdapters.Jasmine
+{
+    public class JasminTestContentTypeDefinition
+    {
+        public const string JasminTestContentType = "JasminTest";
+
+        [Export(typeof(ContentTypeDefinition))]
+        [Name(JasminTestContentType)]
+        [BaseDefinition("JavaScript")]
+        public ContentTypeDefinition IAppCacheContentType { get; set; }
+
+        [Export(typeof(FileExtensionToContentTypeDefinition))]
+        [ContentType(JasminTestContentType)]
+        [FileExtension(".jstests")]
+        public FileExtensionToContentTypeDefinition AppCacheFileExtension { get; set; }
+    }
+}


### PR DESCRIPTION
This commit also adds information about how to run the VSIX in the project file. For some reason, this has to be added manually unless you have the user file.
